### PR TITLE
MNT switch to absolute imports sklearn/utils/_random.pyx (Part of scikit-learn#32315)

### DIFF
--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -11,9 +11,9 @@ The module contains:
     * Fast rand_r alternative based on xor shifts
 """
 import numpy as np
-from . import check_random_state
+from sklearn.utils.validation import check_random_state
 
-from ._typedefs cimport intp_t
+from sklearn.utils._typedefs cimport intp_t
 
 
 cdef uint32_t DEFAULT_SEED = 1


### PR DESCRIPTION



#### What does this implement/fix? Explain your changes.

Line 14: Changed `from . import check_random_state` to `from sklearn.utils.validation import check_random_state`
Line 16: changed `from ._typedefs cimport intp_t` to `from sklearn.utils._typedefs cimport intp_t`

#### Any other comments?
No

Use absolute imports in Cython code #1 